### PR TITLE
DTRA-2225 / Kate / Update colors

### DIFF
--- a/chart_app/lib/deriv_chart_wrapper.dart
+++ b/chart_app/lib/deriv_chart_wrapper.dart
@@ -251,11 +251,17 @@ class DerivChartWrapperState extends State<DerivChartWrapper> {
 
                     final bool isTickGranularity = granularity < 60000;
 
+                    final bool isLightMode =
+                        configModel.theme is ChartDefaultLightTheme;
+
                     final DataSeries<Tick> mainSeries =
                         getDataSeries(feedModel, configModel, granularity);
 
-                    final Color latestTickColor = Color.fromRGBO(
-                        255, 68, 81, configModel.isSymbolClosed ? 0.32 : 1);
+                    final Color latestTickColor = isLightMode
+                        ? Color.fromRGBO(
+                            0, 0, 0, configModel.isSymbolClosed ? 0.32 : 1)
+                        : Color.fromRGBO(255, 255, 255,
+                            configModel.isSymbolClosed ? 0.32 : 1);
 
                     final Duration animationDuration = _getAnimationDuration(
                         isTickGranularity: isTickGranularity);
@@ -274,14 +280,16 @@ class DerivChartWrapperState extends State<DerivChartWrapper> {
                                   id: 'last_tick_indicator',
                                   style: HorizontalBarrierStyle(
                                       color: latestTickColor,
-                                      labelShape: LabelShape.pentagon,
                                       hasArrow: false,
-                                      textStyle: const TextStyle(
+                                      labelHeight: 26,
+                                      textStyle: TextStyle(
                                         fontSize: 12,
-                                        height: 1.3,
+                                        height: 1.8,
                                         fontWeight: FontWeight.w600,
-                                        color: Colors.white,
-                                        fontFeatures: <FontFeature>[
+                                        color: isLightMode
+                                            ? Colors.white
+                                            : Colors.black,
+                                        fontFeatures: const <FontFeature>[
                                           FontFeature.tabularFigures()
                                         ],
                                       )),
@@ -289,12 +297,15 @@ class DerivChartWrapperState extends State<DerivChartWrapper> {
                                       .keepBarrierLabelVisible,
                                 ),
                               if (configModel.isLive)
-                                BlinkingTickIndicator(
-                                  feedModel.ticks.last,
-                                  id: 'blink_tick_indicator',
-                                  visibility: HorizontalBarrierVisibility
-                                      .keepBarrierLabelVisible,
-                                ),
+                                BlinkingTickIndicator(feedModel.ticks.last,
+                                    id: 'blink_tick_indicator',
+                                    visibility: HorizontalBarrierVisibility
+                                        .keepBarrierLabelVisible,
+                                    style: HorizontalBarrierStyle(
+                                      color: isLightMode
+                                          ? Colors.black
+                                          : Colors.white,
+                                    )),
                               if (app.configModel.showTimeInterval &&
                                   !isTickGranularity)
                                 TimeIntervalIndicator(
@@ -302,8 +313,7 @@ class DerivChartWrapperState extends State<DerivChartWrapper> {
                                   feedModel.ticks.last.close,
                                   longLine: false,
                                   style: HorizontalBarrierStyle(
-                                    color: configModel.theme
-                                            is ChartDefaultLightTheme
+                                    color: isLightMode
                                         ? Colors.black
                                         : Colors.white,
                                     hasArrow: false,
@@ -311,8 +321,7 @@ class DerivChartWrapperState extends State<DerivChartWrapper> {
                                       fontSize: 12,
                                       height: 1.3,
                                       fontWeight: FontWeight.w600,
-                                      color: configModel.theme
-                                              is ChartDefaultLightTheme
+                                      color: isLightMode
                                           ? Colors.white
                                           : Colors.black,
                                       fontFeatures: const <FontFeature>[

--- a/chart_app/lib/deriv_chart_wrapper.dart
+++ b/chart_app/lib/deriv_chart_wrapper.dart
@@ -281,7 +281,6 @@ class DerivChartWrapperState extends State<DerivChartWrapper> {
                                   style: HorizontalBarrierStyle(
                                       color: latestTickColor,
                                       hasArrow: false,
-                                      labelHeight: 26,
                                       textStyle: TextStyle(
                                         fontSize: 12,
                                         height: 1.8,

--- a/chart_app/lib/deriv_chart_wrapper.dart
+++ b/chart_app/lib/deriv_chart_wrapper.dart
@@ -284,7 +284,7 @@ class DerivChartWrapperState extends State<DerivChartWrapper> {
                                       hasArrow: false,
                                       textStyle: TextStyle(
                                         fontSize: 12,
-                                        height: 1.8,
+                                        height: 1.3,
                                         fontWeight: FontWeight.w600,
                                         color: isLightMode
                                             ? Colors.white

--- a/chart_app/lib/deriv_chart_wrapper.dart
+++ b/chart_app/lib/deriv_chart_wrapper.dart
@@ -279,6 +279,7 @@ class DerivChartWrapperState extends State<DerivChartWrapper> {
                                   feedModel.ticks.last,
                                   id: 'last_tick_indicator',
                                   style: HorizontalBarrierStyle(
+                                      labelPadding: 8,
                                       color: latestTickColor,
                                       hasArrow: false,
                                       textStyle: TextStyle(

--- a/chart_app/lib/src/helpers/series.dart
+++ b/chart_app/lib/src/helpers/series.dart
@@ -1,20 +1,21 @@
 import 'package:chart_app/src/models/chart_config.dart';
 import 'package:chart_app/src/models/chart_feed.dart';
 import 'package:chart_app/src/series/custom_line_series.dart';
-import 'package:deriv_chart/deriv_chart.dart';
+import 'package:deriv_chart/deriv_chart.dart' hide CandleSeries;
 import 'package:flutter/material.dart';
+import '../series/candle_series.dart';
 
 /// Gets the data series
 DataSeries<Tick> getDataSeries(
     ChartFeedModel feedModel, ChartConfigModel configModel, int granularity) {
   final List<Tick> ticks = feedModel.ticks;
   final double opacity = configModel.isSymbolClosed ? 0.32 : 1;
+  final bool isLightMode = configModel.theme is ChartDefaultLightTheme;
   // Min granularity 1m
   if (ticks is List<Candle> && granularity >= 60000) {
     final CandleStyle style = CandleStyle(
-      positiveColor: Color.fromRGBO(76, 175, 80, opacity),
-      negativeColor: Color.fromRGBO(249, 84, 84, opacity),
-      neutralColor: Color.fromRGBO(85, 89, 117, opacity),
+      positiveColor: Color.fromRGBO(0, 195, 144, opacity),
+      negativeColor: Color.fromRGBO(222, 0, 64, opacity),
     );
 
     switch (configModel.style) {
@@ -31,7 +32,9 @@ DataSeries<Tick> getDataSeries(
   return CustomLineSeries(
     ticks,
     style: LineStyle(
-      color: Color.fromRGBO(133, 172, 176, opacity),
+      color: isLightMode
+          ? Color.fromRGBO(0, 0, 0, opacity)
+          : Color.fromRGBO(255, 255, 255, opacity),
       hasArea: true,
     ),
   );

--- a/chart_app/lib/src/painters/blink_tick_painter.dart
+++ b/chart_app/lib/src/painters/blink_tick_painter.dart
@@ -17,7 +17,10 @@ class BlinkingTickPainter<T extends BlinkingTickIndicator>
     required QuoteToY quoteToY,
     required AnimationInfo animationInfo,
   }) {
-    final Paint _paint = Paint()..color = Colors.redAccent;
+    final HorizontalBarrierStyle style =
+        series.style as HorizontalBarrierStyle? ?? theme.horizontalBarrierStyle;
+
+    final Paint _paint = Paint()..color = style.color;
 
     /// Animated Value
     double? animatedValue;
@@ -57,7 +60,7 @@ class BlinkingTickPainter<T extends BlinkingTickIndicator>
         YAxisConfig.instance.yAxisClipping(canvas, size, () {
           canvas.drawCircle(
             Offset(dotX!, y),
-            3 + (animationInfo.currentTickPercent * 6),
+            4 + (animationInfo.currentTickPercent * 6),
             Paint()..color = _paint.color.withOpacity(0.15),
           );
         });
@@ -65,7 +68,7 @@ class BlinkingTickPainter<T extends BlinkingTickIndicator>
       YAxisConfig.instance.yAxisClipping(canvas, size, () {
         canvas.drawCircle(
           Offset(dotX!, y),
-          3,
+          4,
           _paint,
         );
       });

--- a/chart_app/lib/src/series/candle_painter.dart
+++ b/chart_app/lib/src/series/candle_painter.dart
@@ -1,0 +1,66 @@
+import 'package:deriv_chart/deriv_chart.dart';
+import 'package:flutter/material.dart';
+
+/// A [DataPainter] for painting CandleStick data.
+class CandlePainter extends OhlcPainter {
+  /// Initializes
+  CandlePainter(DataSeries<Candle> series) : super(series);
+
+  late Paint _linePaint;
+  late Paint _positiveCandlePaint;
+  late Paint _negativeCandlePaint;
+
+  @override
+  void onPaintCandle(
+    Canvas canvas,
+    OhlcPainting currentPainting,
+    OhlcPainting prevPainting,
+  ) {
+    final CandleStyle style = series.style as CandleStyle? ?? theme.candleStyle;
+
+    _linePaint = Paint()
+      ..color = currentPainting.yOpen > currentPainting.yClose
+          ? style.positiveColor
+          : style.negativeColor
+      ..strokeWidth = 1.2;
+
+    _positiveCandlePaint = Paint()..color = style.positiveColor;
+    _negativeCandlePaint = Paint()..color = style.negativeColor;
+
+    canvas.drawLine(
+      Offset(currentPainting.xCenter, currentPainting.yHigh),
+      Offset(currentPainting.xCenter, currentPainting.yLow),
+      _linePaint,
+    );
+
+    if (currentPainting.yOpen == currentPainting.yClose) {
+      canvas.drawLine(
+        Offset(currentPainting.xCenter - currentPainting.width / 2,
+            currentPainting.yOpen),
+        Offset(currentPainting.xCenter + currentPainting.width / 2,
+            currentPainting.yOpen),
+        _linePaint,
+      );
+    } else if (currentPainting.yOpen > currentPainting.yClose) {
+      canvas.drawRect(
+        Rect.fromLTRB(
+          currentPainting.xCenter - currentPainting.width / 2,
+          currentPainting.yClose,
+          currentPainting.xCenter + currentPainting.width / 2,
+          currentPainting.yOpen,
+        ),
+        _positiveCandlePaint,
+      );
+    } else {
+      canvas.drawRect(
+        Rect.fromLTRB(
+          currentPainting.xCenter - currentPainting.width / 2,
+          currentPainting.yOpen,
+          currentPainting.xCenter + currentPainting.width / 2,
+          currentPainting.yClose,
+        ),
+        _negativeCandlePaint,
+      );
+    }
+  }
+}

--- a/chart_app/lib/src/series/candle_series.dart
+++ b/chart_app/lib/src/series/candle_series.dart
@@ -1,0 +1,23 @@
+import 'package:deriv_chart/deriv_chart.dart' hide OHLCTypeSeries;
+import 'package:deriv_chart/src/deriv_chart/chart/data_visualization/chart_series/ohlc_series/ohlc_type_series.dart';
+import './candle_painter.dart';
+
+/// CandleStick series
+class CandleSeries extends OHLCTypeSeries {
+  /// Initializes
+  CandleSeries(
+    List<Candle> entries, {
+    String? id,
+    String? painterType,
+    CandleStyle? style,
+    HorizontalBarrierStyle? lastTickIndicatorStyle,
+  }) : super(
+          entries,
+          id ?? 'CandleSeries',
+          style: style,
+          lastTickIndicatorStyle: lastTickIndicatorStyle,
+        );
+
+  @override
+  SeriesPainter<DataSeries<Candle>> createPainter() => CandlePainter(this);
+}

--- a/sass/components/_barrier.scss
+++ b/sass/components/_barrier.scss
@@ -96,6 +96,7 @@
     right: -1px;
     background-color: $color-blue;
     justify-content: space-between;
+    border-radius: 4px;
 
     .arrow-icon {
         height: 41px;

--- a/src/components/PriceLine.tsx
+++ b/src/components/PriceLine.tsx
@@ -95,6 +95,8 @@ const PriceLine = ({
                             width: isOverlappingWithPriceLine ? overlappedBarrierWidth : width,
                             opacity,
                             right: price_right_offset,
+                            borderTopRightRadius: isOverlappingWithPriceLine ? 0 : 4,
+                            borderBottomRightRadius: isOverlappingWithPriceLine ? 0 : 4,
                         }}
                     >
                         <HamburgerDragIcon />
@@ -117,7 +119,13 @@ const PriceLine = ({
                     {isOverlappingWithPriceLine && (
                         <div
                             className='price-overlay'
-                            style={{ backgroundColor: color, width: width - overlappedBarrierWidth + 6, right: isMobile ? 20 : 3 }}
+                            style={{
+                                backgroundColor: color,
+                                width: width - overlappedBarrierWidth + 6,
+                                right: isMobile ? 20 : 3,
+                                borderTopRightRadius: isOverlappingWithPriceLine ? 4 : 0,
+                                borderBottomRightRadius: isOverlappingWithPriceLine ? 4 : 0,
+                            }}
                         />
                     )}
                 </div>

--- a/src/components/PriceLine.tsx
+++ b/src/components/PriceLine.tsx
@@ -59,7 +59,8 @@ const PriceLine = ({
     if (!showBarrier) return null;
 
     const width = priceLineWidth + 12;
-    const price_right_offset = (isOverlappingWithPriceLine ? width - overlappedBarrierWidth : 0) + (isMobile ? 20 : 3);
+    const price_right_offset =
+        (isOverlappingWithPriceLine ? width + 6 - overlappedBarrierWidth : 0) + (isMobile ? 20 : 3);
 
     return (
         <div


### PR DESCRIPTION
- Updated spot price color, label (paddings, shape) and dot as per Figma 
- Updated the color of the Area chart and shadow as per Figma
- Update the color of the Candle&Hollow&OHLC (should have the same color as purchase btn in V2)
- Update the color of Y-axis of the Candle&Hollow&OHLC (should have the same color as candle)
- Add border radius to barrier
- Added colors based on current selected theme
- Passed some new props to HorizontalBarrierStyle (Flutter PR [link](https://github.com/regentmarkets/flutter-chart/pull/344))

<img width="458" alt="Screenshot 2024-11-05 at 5 49 38 PM" src="https://github.com/user-attachments/assets/858b845d-a047-498c-b64d-fa4270f463bf">
<img width="458" alt="Screenshot 2024-11-05 at 5 49 44 PM" src="https://github.com/user-attachments/assets/37bf792c-168e-4a31-9f37-8d516041f852">
<img width="458" alt="Screenshot 2024-11-05 at 5 50 03 PM" src="https://github.com/user-attachments/assets/f30cac6a-1f42-403e-9759-a6f3403985ba">
<img width="1709" alt="Screenshot 2024-11-05 at 5 48 22 PM" src="https://github.com/user-attachments/assets/8f90ef47-23d4-4ac7-83b3-4767a37580ba">
<img width="1709" alt="Screenshot 2024-11-05 at 5 48 00 PM" src="https://github.com/user-attachments/assets/e4876baf-9300-4e18-a254-b62200ae2f17">