### PR TITLE
DTRA-2226 / Kate / Dark theme, barrier and markers changes

### DIFF
--- a/chart_app/lib/main.dart
+++ b/chart_app/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:chart_app/deriv_chart_wrapper.dart';
 import 'package:chart_app/src/chart_app.dart';
+import 'package:chart_app/src/helpers/color.dart';
 import 'package:chart_app/src/misc/no_navigation_strategy.dart';
 import 'package:chart_app/src/models/drawing_tool.dart';
 import 'package:chart_app/src/models/indicators.dart';
@@ -112,7 +113,7 @@ class _DerivChartWebAdapterState extends State<_DerivChartWebAdapter> {
                         return Container(
                           color: configModel.theme is ChartDefaultLightTheme
                               ? Colors.white
-                              : Colors.black,
+                              : getColorFromString('rgba(24, 28, 37, 1)'),
                           constraints: const BoxConstraints.expand(),
                         );
                       }

--- a/chart_app/lib/src/models/chart_config.dart
+++ b/chart_app/lib/src/models/chart_config.dart
@@ -1,9 +1,10 @@
 import 'package:chart_app/src/helpers/color.dart';
 import 'package:chart_app/src/markers/marker_group.dart';
 import 'package:chart_app/src/markers/web_marker.dart';
-import 'package:deriv_chart/deriv_chart.dart';
+import 'package:deriv_chart/deriv_chart.dart' hide ChartDefaultDarkTheme;
 import 'package:flutter/material.dart';
 import 'package:chart_app/src/interop/js_interop.dart';
+import './chart_default_dark_theme.dart';
 
 /// State and methods of chart web adapter config.
 class ChartConfigModel extends ChangeNotifier {

--- a/chart_app/lib/src/models/chart_default_dark_theme.dart
+++ b/chart_app/lib/src/models/chart_default_dark_theme.dart
@@ -1,0 +1,44 @@
+import 'package:deriv_chart/src/theme/text_styles.dart';
+import 'package:flutter/material.dart';
+import 'package:deriv_chart/deriv_chart.dart';
+import '../helpers/color.dart';
+
+/// An implementation of [ChartDefaultTheme] which provides access to
+/// dark theme-related colors and styles for the chart package.
+class ChartDefaultDarkTheme extends ChartDefaultTheme {
+  @override
+  Color get accentRedColor => Color(0xFFCC2E3D);
+
+  @override
+  Color get accentGreenColor => Color(0xFF00A79E);
+
+  @override
+  Color get accentYellowColor => Color(0xFFFFAD3A);
+
+  @override
+  Color get base01Color => Color(0xFFFFFFFF);
+
+  @override
+  Color get base02Color => Color(0xFFEAECED);
+
+  @override
+  Color get base03Color => Color(0xFFC2C2C2);
+
+  @override
+  Color get base04Color => Color(0xFF6E6E6E);
+
+  @override
+  Color get base05Color => Color(0xFF3E3E3E);
+
+  @override
+  Color get base06Color => Color(0xFF323738);
+
+  @override
+  Color get base07Color => getColorFromString('rgba(255, 255, 255, 0.04)');
+
+  @override
+  Color get base08Color => getColorFromString('rgba(24, 28, 37, 1)');
+
+  @override
+  TextStyle get overLine => TextStyles.overLine;
+}

--- a/sass/_themes.scss
+++ b/sass/_themes.scss
@@ -1,25 +1,25 @@
 /* stylelint-disable color-no-hex */
 /* stylelint-disable value-keyword-case */
 // Colours based on Zeplin style guide 28march 2019
-$COLOR_WHITE        : #ffffff;
-$COLOR_BLACK        : #000000;
-$COLOR_ORANGE       : #ff9933;
-$COLOR_SKY_BLUE     : #2196f3;
-$COLOR_GREEN_2      : #2d9f93;
-$COLOR_PURPLE       : #4f60ae;
-$COLOR_DARK_BLUE_1  : #0b0e18;
-$COLOR_DARK_BLUE_2  : #101320;
-$COLOR_DARK_BLUE_3  : #191c31;
-$COLOR_DARK_BLUE_4  : #202641;
-$COLOR_DARK_BLUE_5  : #2a3052; /* Brand Blue */
-$COLOR_DARK_GRAY_1  : #282a37;
-$COLOR_DARK_GRAY_2  : #303342;
-$COLOR_DARK_GRAY_3  : #555975;
-$COLOR_LIGHT_GRAY   : #7f8397;
+$COLOR_WHITE: #ffffff;
+$COLOR_BLACK: #000000;
+$COLOR_ORANGE: #ff9933;
+$COLOR_SKY_BLUE: #2196f3;
+$COLOR_GREEN_2: #2d9f93;
+$COLOR_PURPLE: #4f60ae;
+$COLOR_DARK_BLUE_1: #0b0e18;
+$COLOR_DARK_BLUE_2: #101320;
+$COLOR_DARK_BLUE_3: #191c31;
+$COLOR_DARK_BLUE_4: #202641;
+$COLOR_DARK_BLUE_5: #2a3052; /* Brand Blue */
+$COLOR_DARK_GRAY_1: #282a37;
+$COLOR_DARK_GRAY_2: #303342;
+$COLOR_DARK_GRAY_3: #555975;
+$COLOR_LIGHT_GRAY: #7f8397;
 $COLOR_LIGHT_GRAY_30: rgba($COLOR_LIGHT_GRAY, 0.3);
-$COLOR_LIGHT_GRAY_1 : #999cac;
-$COLOR_LIGHT_GRAY_2 : rgba($COLOR_LIGHT_GRAY_1, 0.32);
-$COLOR_LIGHT_GRAY_3 : rgb(250, 250, 251);
+$COLOR_LIGHT_GRAY_1: #999cac;
+$COLOR_LIGHT_GRAY_2: rgba($COLOR_LIGHT_GRAY_1, 0.32);
+$COLOR_LIGHT_GRAY_3: rgb(250, 250, 251);
 $COLOR_LIGHT_BLACK_1: rgba($COLOR_BLACK, 0.8);
 $COLOR_LIGHT_BLACK_1_40: rgba($COLOR_BLACK, 0.4);
 $COLOR_LIGHT_BLACK_3: rgba($COLOR_BLACK, 0.16);
@@ -32,13 +32,13 @@ $COLOR_LIGHT_BLACK_6: rgba($COLOR_BLACK, 0.15);
 
 //Legacy Colours. TODO: Check with design team, replace and remove these colours
 //Legacy Colours. TODO: Check with design team, replace and remove these colours
-$COLOR_YELLOW       : #fef1cf;
-$COLOR_LIGHT_BLACK : #5c5c5c;
+$COLOR_YELLOW: #fef1cf;
+$COLOR_LIGHT_BLACK: #5c5c5c;
 $COLOR_BRANDBLUE_40: #aaacba;
 $COLOR_BRANDBLUE_95: #353b5b;
 $COLOR_BRANDBLUE_85: #4a4f6c;
 $COLOR_BRANDBLUE_75: #60647e;
-$COLOR_DARK_BLUE_8 : rgba(127, 131, 151, 0.3);
+$COLOR_DARK_BLUE_8: rgba(127, 131, 151, 0.3);
 
 $COLOR_GREEN: #85acb0;
 $COLOR_GREEN_1: #4bb4b3;
@@ -49,7 +49,7 @@ $COLOR_GREEN_1: #4bb4b3;
  *****************************
 \*****************************/
 
-$color-black: #0e0e0e;
+$color-black: #181c25;
 $color-black-1: #333333;
 $color-black-3: #151717;
 $color-black-4: #1d1f20;
@@ -92,63 +92,63 @@ $color-blue: #377cfc;
 /* Preserve legacy variables */
 /* Primary */
 
-$COLOR_BLACK      : #000000;
-$COLOR_BLACK_2    : #1d1f20;
-$COLOR_BLACK_3    : #0e0e0e;
-$COLOR_GREEN_1    : #39b19d;
-$COLOR_GREEN_2    : #2d9f93;
-$COLOR_GREEN_3    : #21ce99;
-$COLOR_GREEN_4    : #00a79e;
-$COLOR_GREEN_5    : #4bb4b3;
-$COLOR_ORANGE     : #ff9933;
+$COLOR_BLACK: #000000;
+$COLOR_BLACK_2: #1d1f20;
+$COLOR_BLACK_3: #0e0e0e;
+$COLOR_GREEN_1: #39b19d;
+$COLOR_GREEN_2: #2d9f93;
+$COLOR_GREEN_3: #21ce99;
+$COLOR_GREEN_4: #00a79e;
+$COLOR_GREEN_5: #4bb4b3;
+$COLOR_ORANGE: #ff9933;
 $COLOR_DARK_ORANGE: #ff8802;
-$COLOR_PURPLE     : #4f60ae;
-$COLOR_RED        : #e31c4b;
-$COLOR_RED_2      : #cc2e3d;
-$COLOR_RED_3      : #ec3f3f;
-$COLOR_CORAL_RED  : #ff444f;
-$COLOR_SKY_BLUE   : #2196f3;
-$COLOR_WHITE      : #ffffff;
-$COLOR_BLUE       : #1c5ae3;
+$COLOR_PURPLE: #4f60ae;
+$COLOR_RED: #e31c4b;
+$COLOR_RED_2: #cc2e3d;
+$COLOR_RED_3: #ec3f3f;
+$COLOR_CORAL_RED: #ff444f;
+$COLOR_SKY_BLUE: #2196f3;
+$COLOR_WHITE: #ffffff;
+$COLOR_BLUE: #1c5ae3;
 // Light theme
-$COLOR_LIGHT_BLACK_1        : rgba(0, 0, 0, 0.8);
-$COLOR_LIGHT_BLACK_2        : rgba(0, 0, 0, 0.4);
-$COLOR_LIGHT_BLACK_3        : rgba(0, 0, 0, 0.16);
+$COLOR_LIGHT_BLACK_1: rgba(0, 0, 0, 0.8);
+$COLOR_LIGHT_BLACK_2: rgba(0, 0, 0, 0.4);
+$COLOR_LIGHT_BLACK_3: rgba(0, 0, 0, 0.16);
 $COLOR_LIGHT_BLACK_3_SOLID_1: #d6d6d6;
 $COLOR_LIGHT_BLACK_3_SOLID_2: #b3b3b3;
-$COLOR_LIGHT_BLACK_4        : rgba(0, 0, 0, 0.04);
-$COLOR_LIGHT_BLACK_4_SOLID  : #f4f4f6;
-$COLOR_LIGHT_GRAY_1         : #999cac;
-$COLOR_LIGHT_GRAY_2         : rgba(153, 156, 172, 0.32);
-$COLOR_LIGHT_GRAY_3         : #eaeced;
-$COLOR_LIGHT_GRAY_4         : #6e6e6e;
-$COLOR_LIGHT_GRAY_5         : #c2c2c2;
-$COLOR_LIGHT_GRAY_6          : #e9e9ed;
+$COLOR_LIGHT_BLACK_4: rgba(0, 0, 0, 0.04);
+$COLOR_LIGHT_BLACK_4_SOLID: #f4f4f6;
+$COLOR_LIGHT_GRAY_1: #999cac;
+$COLOR_LIGHT_GRAY_2: rgba(153, 156, 172, 0.32);
+$COLOR_LIGHT_GRAY_3: #eaeced;
+$COLOR_LIGHT_GRAY_4: #6e6e6e;
+$COLOR_LIGHT_GRAY_5: #c2c2c2;
+$COLOR_LIGHT_GRAY_6: #e9e9ed;
 $COLOR_LIGHT_GRAY_7: rgba(0, 0, 0, 0.08);
-$COLOR_LIGHT_GREEN_GRADIENT : linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0, 148, 117, 0.16));
-$COLOR_LIGHT_RED_GRADIENT   : linear-gradient(to top, rgba(255, 255, 255, 0), rgba(227, 28, 75, 0.16));
-$COLOR_LIGHT_WHITE_GRADIENT : linear-gradient(to right, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
+$COLOR_LIGHT_GREEN_GRADIENT: linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0, 148, 117, 0.16));
+$COLOR_LIGHT_RED_GRADIENT: linear-gradient(to top, rgba(255, 255, 255, 0), rgba(227, 28, 75, 0.16));
+$COLOR_LIGHT_WHITE_GRADIENT: linear-gradient(to right, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
 // Dark theme
-$COLOR_DARK_BLACK_GRADIENT : linear-gradient(to right, rgba(16, 19, 32, 1), rgba(16, 19, 32, 0));
-$COLOR_DARK_BLUE_1         : #0b0e18;
-$COLOR_DARK_BLUE_2         : #101320;
-$COLOR_DARK_BLUE_3         : #191c31;
-$COLOR_DARK_BLUE_4         : #202641;
-$COLOR_DARK_BLUE_5         : #2a3052;
-$COLOR_DARK_BLUE_6         : #555975;
-$COLOR_DARK_BLUE_7         : #7f8397;
-$COLOR_DARK_BLUE_8         : rgba(127, 131, 151, 0.3);
-$COLOR_DARK_GREEN_GRADIENT : linear-gradient(to top, rgba(16, 19, 32, 0), rgba(0, 148, 117, 0.16));
-$COLOR_DARK_RED_GRADIENT   : linear-gradient(to top, rgba(16, 19, 32, 0), rgba(227, 28, 75, 0.16));
-$COLOR_DARK_GRAY_1         : #282a37;
-$COLOR_DARK_GRAY_2         : #303342;
-$COLOR_DARK_GRAY_3         : #555975;
-$COLOR_DARK_GRAY_4         : #999999;
+$COLOR_DARK_BLACK_GRADIENT: linear-gradient(to right, rgba(16, 19, 32, 1), rgba(16, 19, 32, 0));
+$COLOR_DARK_BLUE_1: #0b0e18;
+$COLOR_DARK_BLUE_2: #101320;
+$COLOR_DARK_BLUE_3: #191c31;
+$COLOR_DARK_BLUE_4: #202641;
+$COLOR_DARK_BLUE_5: #2a3052;
+$COLOR_DARK_BLUE_6: #555975;
+$COLOR_DARK_BLUE_7: #7f8397;
+$COLOR_DARK_BLUE_8: rgba(127, 131, 151, 0.3);
+$COLOR_DARK_GREEN_GRADIENT: linear-gradient(to top, rgba(16, 19, 32, 0), rgba(0, 148, 117, 0.16));
+$COLOR_DARK_RED_GRADIENT: linear-gradient(to top, rgba(16, 19, 32, 0), rgba(227, 28, 75, 0.16));
+$COLOR_DARK_GRAY_1: #282a37;
+$COLOR_DARK_GRAY_2: #303342;
+$COLOR_DARK_GRAY_3: #555975;
+$COLOR_DARK_GRAY_4: #999999;
 
 $themes: (
     light: (
         DefaultMain: $COLOR_WHITE,
-        DefaultBg:  $COLOR_WHITE,
+        DefaultBg: $COLOR_WHITE,
         DefaultText: $COLOR_LIGHT_GRAY,
         BtnDefaultBg: transparent,
         BtnDefaultText: $color-red,
@@ -471,11 +471,11 @@ $themes: (
         ChartHistoricalMarkerFont: $color-black-1,
     ),
     dark: (
-        DefaultMain:            $color-black,
-        DefaultBg:              $color-black,
-        DefaultText:            $COLOR_WHITE,
-        DefaultBorder:          $COLOR_WHITE,
-        TooltipBg:  $color-black-8,
+        DefaultMain: $color-black,
+        DefaultBg: $color-black,
+        DefaultText: $COLOR_WHITE,
+        DefaultBorder: $COLOR_WHITE,
+        TooltipBg: $color-black-8,
         TooltipText: $color-white,
         TooltipShadow: transparent,
         TooltipTextBg: transparent,
@@ -742,7 +742,7 @@ $themes: (
         ChartHistoryPickerFooterBorder: $color-black,
         ChartHistoryPickerFooterColor: $color-grey,
         ChartHistoryPickerBodyColor: $color-grey,
-        ChartHistoryPickerBodyDisableColor:$color-black-6,
+        ChartHistoryPickerBodyDisableColor: $color-black-6,
         ChartHistoryPickerBodyActiveBg: $color-black-8,
         ChartHistoryPickerBodyActiveColor: $COLOR_WHITE,
         ChartHistoryPickerBodyActiveBorder: $color-black-8,
@@ -797,7 +797,12 @@ $themes: (
             $theme-map: () !global;
             @each $key, $submap in $map {
                 $value: map-get(map-get($themes, $theme), '#{$key}');
-                $theme-map: map-merge($theme-map, ($key: $value)) !global;
+                $theme-map: map-merge(
+                    $theme-map,
+                    (
+                        $key: $value,
+                    )
+                ) !global;
             }
             @content;
             $theme-map: null !global;

--- a/sass/_themes.scss
+++ b/sass/_themes.scss
@@ -87,7 +87,7 @@ $color-green-3: #00a79e;
 $color-green-4: #008079;
 $color-orange: #ff6444;
 $color-yellow: #ffad3a;
-$color-blue: #377cfc;
+$color-blue: #2c9aff;
 
 /* Preserve legacy variables */
 /* Primary */

--- a/sass/components/_barrier.scss
+++ b/sass/components/_barrier.scss
@@ -83,13 +83,17 @@
 
 .drag-price {
     display: flex;
-    height: 24px;
-    top: -12px;
+    height: 21px;
+    top: -10px;
     position: absolute;
     right: -1px;
-    background-color: $color-blue;
     justify-content: space-between;
+    border: 1px solid;
     border-radius: 4px;
+
+    @include themify($themes) {
+        background: themed('DefaultMain');
+    }
 
     .arrow-icon {
         height: 41px;
@@ -104,10 +108,8 @@
 .price {
     display: block;
     font-size: 12px;
-    font-weight: bold;
     line-height: 18px;
     overflow: unset;
-    padding: 3px 1px;
     position: relative;
     right: 45px;
     text-align: center;
@@ -116,18 +118,14 @@
     &--zero {
         color: $color-blue;
         @include themify($themes) {
-            background-color: themed('DefaultBg');
+            /* stylelint-disable number-max-precision, plugin/no-unsupported-browser-features */
+            background-image: linear-gradient(
+                rgba(255, 255, 255, 0.001) 30%,
+                themed('DefaultBg') 50%,
+                rgba(255, 255, 255, 0.001) 75%
+            );
+            /* stylelint-enable number-max-precision, plugin/no-unsupported-browser-features */
         }
-    }
-    &-overlay {
-        /* rtl:begin:ignore */
-        background-color: $color-blue;
-        height: 24px;
-        opacity: 0.3;
-        position: absolute;
-        right: -10px;
-        top: -12px;
-        /* rtl:end:ignore */
     }
 }
 
@@ -144,10 +142,16 @@
         display: flex;
         flex-direction: column;
         justify-content: center;
-        margin-left: 3px;
+        padding-left: 3px;
+        border-top-left-radius: 4px;
+        border-bottom-left-radius: 4px;
+
+        @include themify($themes) {
+            background: themed('DefaultMain');
+        }
 
         div {
-            background-color: $color-white;
+            background-color: $color-blue;
             height: 1px;
             margin: 1px;
             width: 8px;

--- a/sass/components/_barrier.scss
+++ b/sass/components/_barrier.scss
@@ -52,13 +52,6 @@
             $title-height: 24px;
             position: absolute;
             height: $title-height;
-            /* stylelint-disable number-max-precision, plugin/no-unsupported-browser-features */
-            background-image: linear-gradient(
-                rgba(255, 255, 255, 0.001) 30%,
-                var(--general-main-1) 50%,
-                rgba(255, 255, 255, 0.001) 75%
-            );
-            /* stylelint-enable number-max-precision, plugin/no-unsupported-browser-features */
             top: -11px;
             display: flex;
             align-items: center;
@@ -96,6 +89,7 @@
     right: -1px;
     background-color: $color-blue;
     justify-content: space-between;
+    border-radius: 4px;
 
     .arrow-icon {
         height: 41px;
@@ -103,7 +97,6 @@
         position: absolute;
         transition: none;
         left: 2px;
-        background: var(--general-main-1);
         width: calc(100% - 2px);
     }
 }

--- a/sass/components/_barrier.scss
+++ b/sass/components/_barrier.scss
@@ -83,8 +83,8 @@
 
 .drag-price {
     display: flex;
-    height: 21px;
-    top: -10px;
+    height: 24px;
+    top: -12px;
     position: absolute;
     right: -1px;
     justify-content: space-between;
@@ -92,7 +92,15 @@
     border-radius: 4px;
 
     @include themify($themes) {
-        background: themed('DefaultMain');
+        &:not(&--narrow) {
+            background-color: themed('DefaultMain');
+        }
+    }
+
+    &--narrow {
+        height: 21px;
+        top: -10px;
+        background-color: rgba(12, 40, 247, 0.16);
     }
 
     .arrow-icon {
@@ -110,6 +118,7 @@
     font-size: 12px;
     line-height: 18px;
     overflow: unset;
+    padding: 3px 1px;
     position: relative;
     right: 45px;
     text-align: center;
@@ -117,6 +126,8 @@
 
     &--zero {
         color: $color-blue;
+        padding: unset;
+
         @include themify($themes) {
             /* stylelint-disable number-max-precision, plugin/no-unsupported-browser-features */
             background-image: linear-gradient(

--- a/sass/components/_barrier.scss
+++ b/sass/components/_barrier.scss
@@ -102,7 +102,6 @@
         top: -10px;
         background-color: rgba(12, 40, 247, 0.16);
     }
-
     .arrow-icon {
         height: 41px;
         padding: 4px 0px;

--- a/src/components/Barrier.tsx
+++ b/src/components/Barrier.tsx
@@ -18,7 +18,7 @@ const Barrier = ({ store, ...props }: TBarrierBaseProps) => {
         aboveShadeStore,
         belowShadeStore,
         betweenShadeStore,
-        color = '#39b19d',
+        color = '#008832',
         foregroundColor = '#ffffff',
         hideBarrierLine,
         hideOffscreenBarrier,
@@ -28,7 +28,7 @@ const Barrier = ({ store, ...props }: TBarrierBaseProps) => {
         isSingleBarrier,
         lineStyle,
         opacityOnOverlap,
-        shadeColor = '#39b19d',
+        shadeColor = '#008832',
     } = store;
 
     const barrierRef = React.useRef<HTMLDivElement>(null);

--- a/src/components/PriceLine.tsx
+++ b/src/components/PriceLine.tsx
@@ -89,9 +89,8 @@ const PriceLine = ({
                 <div className='draggable-area' />
                 <div className='draggable-area-wrapper'>
                     <div
-                        className='drag-price'
+                        className={classNames('drag-price', { 'drag-price--narrow': isOverlappingWithPriceLine })}
                         style={{
-                            backgroundColor: isOverlappingWithPriceLine ? 'rgba(12, 40, 247, 0.16)' : '',
                             color,
                             borderColor: color,
                             width: draggable && isOverlappingWithPriceLine ? width + 6 : width - 6,
@@ -105,7 +104,7 @@ const PriceLine = ({
                             style={{
                                 color: isOverlappingWithPriceLine ? color : '',
                                 right: isOverlappingWithPriceLine
-                                    ? overlappedBarrierWidth + 6 + priceDisplay.length * 8 + (draggable ? 16 : 0)
+                                    ? overlappedBarrierWidth + 6 + priceDisplay.length * 8 + (draggable ? 26 : 0)
                                     : 0,
                             }}
                         >

--- a/src/components/PriceLine.tsx
+++ b/src/components/PriceLine.tsx
@@ -96,8 +96,6 @@ const PriceLine = ({
                             width: draggable && isOverlappingWithPriceLine ? width + 6 : width - 6,
                             opacity,
                             right: price_right_offset,
-                            borderTopRightRadius: isOverlappingWithPriceLine ? 0 : 4,
-                            borderBottomRightRadius: isOverlappingWithPriceLine ? 0 : 4,
                         }}
                     >
                         <HamburgerDragIcon />

--- a/src/components/PriceLine.tsx
+++ b/src/components/PriceLine.tsx
@@ -59,7 +59,7 @@ const PriceLine = ({
     if (!showBarrier) return null;
 
     const width = priceLineWidth + 12;
-    const price_right_offset = (isOverlappingWithPriceLine ? width - overlappedBarrierWidth : 0) + (isMobile ? 20 : 3);
+    const price_right_offset = isMobile ? 20 : 3;
 
     return (
         <div
@@ -82,7 +82,7 @@ const PriceLine = ({
                         style={{
                             borderTopColor: color,
                             borderTopStyle: lineStyle as React.CSSProperties['borderTopStyle'],
-                            width: `calc(100% - ${width}px + ${!isMobile ? overlappedBarrierWidth : 0}px)`,
+                            width: `calc(100% - ${width}px + ${isMobile ? 0 : overlappedBarrierWidth - 4}px)`,
                         }}
                     />
                 )}
@@ -91,8 +91,10 @@ const PriceLine = ({
                     <div
                         className='drag-price'
                         style={{
-                            backgroundColor: color,
-                            width: isOverlappingWithPriceLine ? overlappedBarrierWidth : width,
+                            backgroundColor: isOverlappingWithPriceLine ? 'rgba(12, 40, 247, 0.16)' : '',
+                            color,
+                            borderColor: color,
+                            width: draggable && isOverlappingWithPriceLine ? width + 6 : width - 6,
                             opacity,
                             right: price_right_offset,
                         }}
@@ -103,7 +105,7 @@ const PriceLine = ({
                             style={{
                                 color: isOverlappingWithPriceLine ? color : '',
                                 right: isOverlappingWithPriceLine
-                                    ? overlappedBarrierWidth + priceDisplay.length * 8 - (!draggable ? 16 : 0)
+                                    ? overlappedBarrierWidth + 6 + priceDisplay.length * 8 + (draggable ? 16 : 0)
                                     : 0,
                             }}
                         >
@@ -114,12 +116,6 @@ const PriceLine = ({
                             <PriceLineArrow offScreenDirection={offScreenDirection} color={color} />
                         )}
                     </div>
-                    {isOverlappingWithPriceLine && (
-                        <div
-                            className='price-overlay'
-                            style={{ backgroundColor: color, width: width - overlappedBarrierWidth + 6, right: isMobile ? 20 : 3 }}
-                        />
-                    )}
                 </div>
                 {title && (
                     <PriceLineTitle


### PR DESCRIPTION
- Updated colors for barrier (+shape), chart background and indicators (+shape).
- Removed barrier shadow gradient
- Updated overlapping logic

![Screenshot 2024-11-11 at 4 37 11 PM](https://github.com/user-attachments/assets/cae17ec6-9f59-4502-a5d6-436aa8689b2d)
![Screenshot 2024-11-11 at 4 36 44 PM](https://github.com/user-attachments/assets/cfb31eba-9d1f-455e-b595-c2074cdddb2d)
![Screenshot 2024-11-11 at 4 42 01 PM](https://github.com/user-attachments/assets/e4f27250-f5b8-45c6-b92f-80e1afbff84d)
![Screenshot 2024-11-11 at 4 36 35 PM](https://github.com/user-attachments/assets/a82bc5a9-0135-41fc-b99b-b88eeb960a33)
![Screenshot 2024-11-11 at 4 41 09 PM](https://github.com/user-attachments/assets/ceaab4fd-391f-4a5d-b420-31c6958f043a)
![Screenshot 2024-11-11 at 4 36 26 PM](https://github.com/user-attachments/assets/c24fa40d-5d89-4bc1-96d1-0fa9ef971020)
![Screenshot 2024-11-11 at 4 39 51 PM](https://github.com/user-attachments/assets/e6d46adb-fe39-40df-ba0e-171335302152)
![Screenshot 2024-11-11 at 4 36 12 PM](https://github.com/user-attachments/assets/752705c7-4078-4c8a-aa39-6ce377c16142)
![Screenshot 2024-11-11 at 4 39 27 PM](https://github.com/user-attachments/assets/b373fb1b-e5ef-4e33-8971-70bc5ecd717f)
![Screenshot 2024-11-11 at 4 36 03 PM](https://github.com/user-attachments/assets/be4609eb-9bd4-4df6-8af6-a0cde5eb0fce)
![Screenshot 2024-11-11 at 4 38 28 PM](https://github.com/user-attachments/assets/4525d439-5e8c-4355-b46d-9e5ac8ddf560)
![Screenshot 2024-11-11 at 4 35 55 PM](https://github.com/user-attachments/assets/c57f2f07-5578-40c5-9248-ace458493145)
![Screenshot 2024-11-11 at 4 38 07 PM](https://github.com/user-attachments/assets/a8a341a0-71cb-4d0a-bead-cac83320a874)
![Screenshot 2024-11-11 at 4 35 41 PM](https://github.com/user-attachments/assets/77b16791-19f8-40a7-afa8-5ed674b58caf)
![Screenshot 2024-11-11 at 4 37 34 PM](https://github.com/user-attachments/assets/65b01cc3-2a22-4dac-8d11-70e7aab48992)
