### PR TITLE
Rename binary-com organization to deriv-com

### DIFF
--- a/.github/workflows/generate_preview_link.yml
+++ b/.github/workflows/generate_preview_link.yml
@@ -29,27 +29,27 @@ jobs:
                   head_sha: ${{github.event.pull_request.head.sha}}
 
             - name: Checkout SmartCharts
-              uses: 'binary-com/SmartCharts/.github/actions/checkout@master'
+              uses: 'deriv-com/SmartCharts/.github/actions/checkout@master'
               with:
                   repository: ${{github.event.pull_request.user.login}}/SmartCharts
                   path: SmartCharts
                   ref: ${{github.head_ref}}
-                  alternate_repository: 'binary-com/SmartCharts'
+                  alternate_repository: 'deriv-com/SmartCharts'
                   alternate_ref: master
 
             - name: Checkout deriv-app
               id: deriv_app
-              uses: 'binary-com/SmartCharts/.github/actions/checkout@master'
+              uses: 'deriv-com/SmartCharts/.github/actions/checkout@master'
               with:
                   repository: ${{github.event.pull_request.user.login}}/deriv-app
                   path: deriv-app
                   ref: ${{github.head_ref}}
-                  alternate_repository: 'binary-com/deriv-app'
+                  alternate_repository: 'deriv-com/deriv-app'
                   alternate_ref: master
 
             - name: Custom flutter-chart
               id: flutter_chart
-              uses: 'binary-com/SmartCharts/.github/actions/checkout@master'
+              uses: 'deriv-com/SmartCharts/.github/actions/checkout@master'
               with:
                   repository: ${{github.event.pull_request.user.login}}/flutter-chart
                   path: flutter-chart

--- a/.github/workflows/publish_deriv_charts_and_update_deriv_app.yml
+++ b/.github/workflows/publish_deriv_charts_and_update_deriv_app.yml
@@ -9,15 +9,15 @@ jobs:
             contents: write
         steps:
             - name: Checkout SmartCharts
-              uses: 'binary-com/SmartCharts/.github/actions/checkout@master'
+              uses: 'deriv-com/SmartCharts/.github/actions/checkout@master'
               with:
-                  repository: 'binary-com/SmartCharts'
+                  repository: 'deriv-com/SmartCharts'
                   path: SmartCharts
                   ref: master
 
             - name: Custom flutter-chart
               id: flutter_chart
-              uses: 'binary-com/SmartCharts/.github/actions/checkout@master'
+              uses: 'deriv-com/SmartCharts/.github/actions/checkout@master'
               with:
                   repository: 'regentmarkets/flutter-chart'
                   path: flutter-chart
@@ -70,7 +70,7 @@ jobs:
         needs: [build_and_publish_deriv_charts]
         steps:
             - name: Checkout deriv-app
-              uses: 'binary-com/SmartCharts/.github/actions/checkout@master'
+              uses: 'deriv-com/SmartCharts/.github/actions/checkout@master'
               with:
                   repository: 'deriv-com/deriv-app'
                   path: deriv-app

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Before running or contribute to this project, you need to have the setup of the 
 2.  **Clone using SSH**
 
     ```sh
-    git clone git@github.com:binary-com/SmartCharts.git
+    git clone git@github.com:deriv-com/SmartCharts.git
     ```
 
 3.  **Enter project directory**
@@ -548,7 +548,7 @@ This has much less freedom compared to [inline SVG](https://github.com/MoOx/reac
 
 SmartCharts uses a variation of [Mobdux](https://medium.com/@cameronfletcher92/mobdux-combining-the-good-parts-of-mobx-and-redux-61bac90ee448) to assist with state management using Mobx.
 
-Each component consists of 2 parts: a **template** (`*.jsx` file), and a **store** (`*Store.js` file). There are 3 scenarios in which the [`connect`](https://github.com/binary-com/SmartCharts/blob/dev/src/store/Connect.js) method is used:
+Each component consists of 2 parts: a **template** (`*.jsx` file), and a **store** (`*Store.js` file). There are 3 scenarios in which the [`connect`](https://github.com/deriv-com/SmartCharts/blob/dev/src/store/Connect.js) method is used:
 
 ##### 1. Main Components: The component is tied directly to the main store.
 

--- a/app/connection/ConnectionManager.ts
+++ b/app/connection/ConnectionManager.ts
@@ -1,5 +1,5 @@
 import EventEmitter from 'event-emitter-es6';
-import { PendingPromise } from '@binary-com/smartcharts'; // eslint-disable-line import/no-extraneous-dependencies,import/no-unresolved
+import { PendingPromise } from '@deriv-com/smartcharts'; // eslint-disable-line import/no-extraneous-dependencies,import/no-unresolved
 // @ts-ignore
 import RobustWebsocket from 'robust-websocket';
 import { IPendingPromise, Listener, TBinaryAPIRequest, TBinaryAPIResponse } from 'src/types';

--- a/app/connection/NetworkMonitor.ts
+++ b/app/connection/NetworkMonitor.ts
@@ -1,4 +1,4 @@
-import { PendingPromise } from '@binary-com/smartcharts';
+import { PendingPromise } from '@deriv-com/smartcharts';
 import { PingResponse } from '@deriv/api-types';
 import { TNetworkConfig, TRequestAPI } from 'src/types';
 // eslint-disable-line import/no-extraneous-dependencies,import/no-unresolved

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -14,7 +14,7 @@ import {
     StudyLegend,
     ToolbarWidget,
     Views,
-} from '@binary-com/smartcharts'; // eslint-disable-line import/no-unresolved
+} from '@deriv-com/smartcharts'; // eslint-disable-line import/no-unresolved
 import whyDidYouRender from '@welldone-software/why-did-you-render';
 import { configure } from 'mobx';
 import moment from 'moment';

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "license": "ISC",
     "repository": {
         "type": "git",
-        "url": "git+ssh://git@github.com/binary-com/SmartCharts.git"
+        "url": "git+ssh://git@github.com/deriv-com/SmartCharts.git"
     },
-    "homepage": "https://github.com/binary-com/SmartCharts#readme",
+    "homepage": "https://github.com/deriv-com/SmartCharts#readme",
     "keywords": [
         "charts",
         "binary.com"

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -9,7 +9,7 @@ module.exports = {
         { name: 'beta', prerelease: true },
         { name: 'alpha', prerelease: true },
     ],
-    repositoryUrl: 'git@github.com:binary-com/SmartCharts.git',
+    repositoryUrl: 'git@github.com:deriv-com/SmartCharts.git',
     plugins: [
         [
             '@semantic-release/commit-analyzer',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "paths": {
-            "@binary-com/smartcharts": ["src/"]
+            "@deriv-com/smartcharts": ["src/"]
         },
         "useDefineForClassFields": true
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ const config = {
     output,
     resolve: {
         alias: {
-            '@binary-com/smartcharts': path.resolve(__dirname, 'src/'),
+            '@deriv-com/smartcharts': path.resolve(__dirname, 'src/'),
             src: path.resolve(__dirname, 'src'),
             chart: path.resolve(__dirname, 'chart_app/build/web'),
         },


### PR DESCRIPTION
Replace references to binary-com to deriv-com organization in workflows and all relevant places.