### PR TITLE
fix: update workflow and pubspec

### DIFF
--- a/.github/workflows/generate_preview_link.yml
+++ b/.github/workflows/generate_preview_link.yml
@@ -60,19 +60,11 @@ jobs:
 
             - uses: subosito/flutter-action@62f096cacda5168a3bd7b95793373be14fa4fbaf
               with:
-                  flutter-version: '3.10.6'
+                  flutter-version: '3.24.1'
                   channel: 'stable'
                   cache: true
 
-            - name: Add SSH key
-              run: |
-                  mkdir -p ~/.ssh
-                  echo "${{ secrets.SSH_KEY }}" > ~/.ssh/github_action_key
-                  chmod 600 ~/.ssh/github_action_key
-
             - name: Build flutter
-              env:
-                  GIT_SSH_COMMAND: 'ssh -i ~/.ssh/github_action_key'
               run: |
                   cd SmartCharts/chart_app
                   flutter pub get

--- a/.github/workflows/publish_deriv_charts_and_update_deriv_app.yml
+++ b/.github/workflows/publish_deriv_charts_and_update_deriv_app.yml
@@ -26,19 +26,11 @@ jobs:
 
             - uses: subosito/flutter-action@62f096cacda5168a3bd7b95793373be14fa4fbaf
               with:
-                  flutter-version: '3.10.6'
+                  flutter-version: '3.24.1'
                   channel: 'stable'
                   cache: true
 
-            - name: Add SSH key
-              run: |
-                  mkdir -p ~/.ssh
-                  echo "${{ secrets.SSH_KEY }}" > ~/.ssh/github_action_key
-                  chmod 600 ~/.ssh/github_action_key
-
             - name: Build flutter
-              env:
-                  GIT_SSH_COMMAND: 'ssh -i ~/.ssh/github_action_key'
               run: |
                   cd SmartCharts/chart_app
                   flutter pub get

--- a/chart_app/pubspec.yaml
+++ b/chart_app/pubspec.yaml
@@ -4,7 +4,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-    sdk: '>=2.16.2 <3.0.0'
+    sdk: '>=3.3.3 <4.0.0'
+    flutter: '3.24.1'
 
 dependencies:
     flutter:
@@ -16,7 +17,7 @@ dependencies:
 dev_dependencies:
     deriv_lint:
         git:
-            url: git@github.com:regentmarkets/flutter-deriv-packages.git
+            url: https://github.com/deriv-com/flutter-deriv-packages.git
             path: packages/deriv_lint
             ref: dev
     flutter_test:


### PR DESCRIPTION
This pull request updates the Flutter and Dart SDK versions used in the project and makes adjustments to the CI workflows to align with these updates. Additionally, it improves the way dependencies are referenced in the `pubspec.yaml` file. The most important changes are grouped below:

**SDK and Dependency Upgrades**

* Updated the Dart SDK requirement in `chart_app/pubspec.yaml` to `>=3.3.3 <4.0.0` and specified the Flutter version as `3.24.1` to ensure compatibility with the latest stable releases.
* Changed the `deriv_lint` dependency source in `chart_app/pubspec.yaml` from an SSH-based GitHub URL to an HTTPS URL for easier access and improved CI reliability.

**CI Workflow Improvements**

* Upgraded the Flutter version used in both `.github/workflows/generate_preview_link.yml` and `.github/workflows/publish_deriv_charts_and_update_deriv_app.yml` from `3.10.6` to `3.24.1` to match the new SDK requirements.
* Removed the SSH key setup and related `GIT_SSH_COMMAND` environment variable from the build steps in both workflows, simplifying the build process and reflecting the switch to HTTPS for dependency fetching.