### PR TITLE
fix: upgrade cipher-base package to resolve security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8610,12 +8610,16 @@
             }
         },
         "node_modules/cipher-base": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.5.tgz",
+            "integrity": "sha512-xq7ICKB4TMHUx7Tz1L9O2SGKOhYMOTR32oir45Bq28/AQTpHogKgHcoYFSdRbMtddl+ozNXfXY9jWcgYKmde0w==",
+            "license": "MIT",
             "dependencies": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
         },
         "node_modules/class-utils": {

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     },
     "overrides": {
         "braces": "^3.0.3",
+        "cipher-base": "1.0.5",
         "webpack-bundle-analyzer": {
             "ws": "^8.18.2"
         }


### PR DESCRIPTION
This pull request introduces a minor dependency override in the `package.json` file to address package management or security concerns.

- Dependency management:
  * Added an override for the `cipher-base` package, setting its version to `1.0.5` in `package.json`.